### PR TITLE
Mark io.github.jonasrutishauser:transactional-event-api as a known compatible bean archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .classpath
 .factorypath
 target/
+
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		<module>transactional-event-liberty-it</module>
 		<module>transactional-event-quarkus</module>
 		<module>transactional-event-quarkus-deployment</module>
+		<module>transactional-event-quarkus-it</module>
 	</modules>
 
 	<build>
@@ -89,7 +90,7 @@
 
 		<log4j.version>2.20.0</log4j.version>
 		<h2.version>2.2.220</h2.version>
-		<quarkus.version>3.17.6</quarkus.version>
+		<quarkus.version>3.30.6</quarkus.version>
 	</properties>
 
 	<scm>

--- a/transactional-event-core/pom.xml
+++ b/transactional-event-core/pom.xml
@@ -12,7 +12,7 @@
 	<name>Transactional Event Library Core</name>
 
 	<properties>
-		<testcontainers.version>1.21.3</testcontainers.version>
+		<testcontainers.version>1.21.4</testcontainers.version>
 		<opentelemetry.version>1.28.0</opentelemetry.version>
 	</properties>
 

--- a/transactional-event-quarkus-deployment/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/deployment/TransactionalEventExtensionProcessor.java
+++ b/transactional-event-quarkus-deployment/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/deployment/TransactionalEventExtensionProcessor.java
@@ -19,6 +19,7 @@ import com.github.jonasrutishauser.transactional.event.quarkus.TransactionalEven
 
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.ExcludedTypeBuildItem;
+import io.quarkus.arc.deployment.KnownCompatibleBeanArchiveBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
@@ -43,6 +44,14 @@ public class TransactionalEventExtensionProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void markApiAsKnownCompatibleBeanArchive(BuildProducer<KnownCompatibleBeanArchiveBuildItem> knownCompatibleBeanArchives){
+        knownCompatibleBeanArchives.produce(
+                KnownCompatibleBeanArchiveBuildItem.builder("io.github.jonasrutishauser", "transactional-event-api")
+                        .addReason(KnownCompatibleBeanArchiveBuildItem.Reason.SPECIALIZES_ANNOTATION).build()
+        );
     }
 
     @BuildStep

--- a/transactional-event-quarkus-it/pom.xml
+++ b/transactional-event-quarkus-it/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.jonasrutishauser</groupId>
+        <artifactId>transactional-event</artifactId>
+        <version>3.3.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>transactional-event-quarkus-it</artifactId>
+
+    <properties>
+        <surefire-plugin.version>3.5.3</surefire-plugin.version>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.jonasrutishauser</groupId>
+            <artifactId>transactional-event-quarkus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/Messages.java
+++ b/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/Messages.java
@@ -1,0 +1,31 @@
+package com.github.jonasrutishauser.transactional.event.quarkus.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+@ApplicationScoped
+public class Messages {
+
+    private final Set<String> items = new CopyOnWriteArraySet<>();
+    private final Set<String> failures = new HashSet<>();
+
+    protected void add(String message) {
+        items.add(message);
+    }
+
+    public Collection<String> get() {
+        return items;
+    }
+
+    protected boolean addFailure(String message) {
+        if (!failures.add(message)) {
+            failures.remove(message);
+            return false;
+        }
+        return true;
+    }
+}

--- a/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestEvent.java
+++ b/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestEvent.java
@@ -1,0 +1,19 @@
+package com.github.jonasrutishauser.transactional.event.quarkus.it;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public class TestEvent {
+
+    private final String message;
+    
+    @JsonbCreator
+    public TestEvent(@JsonbProperty("message") String message) {
+        this.message = message;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestEventHandler.java
+++ b/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestEventHandler.java
@@ -1,0 +1,30 @@
+package com.github.jonasrutishauser.transactional.event.quarkus.it;
+
+import com.github.jonasrutishauser.transactional.event.api.handler.AbstractHandler;
+import com.github.jonasrutishauser.transactional.event.api.handler.EventHandler;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+@Dependent
+@EventHandler
+public class TestEventHandler extends AbstractHandler<TestEvent> {
+
+    private final Messages messages;
+
+    @Inject
+    TestEventHandler(Messages messages) {
+        this.messages = messages;
+    }
+
+    @Override
+    protected void handle(TestEvent event) {
+        if (event.getMessage().contains("failure") && messages.addFailure(event.getMessage())) {
+            throw new IllegalStateException(event.getMessage());
+        }
+        if (event.getMessage().contains("blocker")) {
+            throw new IllegalArgumentException("blocker not allowed");
+        }
+        messages.add(event.getMessage());
+    }
+
+}

--- a/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestResource.java
+++ b/transactional-event-quarkus-it/src/main/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestResource.java
@@ -1,0 +1,42 @@
+package com.github.jonasrutishauser.transactional.event.quarkus.it;
+
+import com.github.jonasrutishauser.transactional.event.api.EventPublisher;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import java.util.Collection;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/test")
+@RequestScoped
+public class TestResource {
+
+    private final EventPublisher publisher;
+
+    private final Messages messages;
+
+    @Inject
+    public TestResource(EventPublisher publisher, Messages messages) {
+        this.publisher = publisher;
+        this.messages = messages;
+    }
+
+    @POST
+    @Transactional
+    public void publish(String message) {
+        publisher.publish(new TestEvent(message));
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Collection<String> getMessages() {
+        return messages.get();
+    }
+
+}

--- a/transactional-event-quarkus-it/src/main/resources/application.properties
+++ b/transactional-event-quarkus-it/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default

--- a/transactional-event-quarkus-it/src/test/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestResourceTest.java
+++ b/transactional-event-quarkus-it/src/test/java/com/github/jonasrutishauser/transactional/event/quarkus/it/TestResourceTest.java
@@ -1,0 +1,46 @@
+package com.github.jonasrutishauser.transactional.event.quarkus.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Callable;
+
+import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+class TestResourceTest {
+    @Test
+    void testRoundTrip() {
+        given().when().body("test message").post("/test").then().statusCode(Response.Status.NO_CONTENT.getStatusCode());
+
+
+        await().until(processMessages(), containsString("test message"));
+    }
+
+    @Test
+    void testFailure() {
+        postMessage("test failure");
+        for (int i = 10; i < 50; i++) {
+            postMessage("failure " + i);
+        }
+
+        await().atMost(1, MINUTES).until(processMessages(), containsString("test failure"));
+        for (int i = 10; i < 50; i++) {
+            await().until(processMessages(), containsString("failure " + i));
+        }
+    }
+
+    private Callable<String> processMessages() {
+        return () -> given().when().get("/test").then()
+                .log().all()
+                .statusCode(Response.Status.OK.getStatusCode()).extract().body().asString();
+    }
+
+    private void postMessage(String message) {
+        given().when().body(message).post("/test").then().statusCode(Response.Status.NO_CONTENT.getStatusCode());
+    }
+}


### PR DESCRIPTION
Mark io.github.jonasrutishauser:transactional-event-api as a known compatible bean archive, even though it contains the jakarta.enterprise.inject.Specializes annotation

- added integration test to make the current build fail
- bump version of testcontainers.version